### PR TITLE
[TASK] Add support for v11 and v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "GPL-2.0-or-later"
     ],
     "require": {
-        "typo3/cms-core": "dev-master",
+        "typo3/cms-core": "dev-master || ^11.5.30 || ^12.4.17 || ^13.2",
         "php": ">=7.4"
     },
     "autoload": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.1.0-11.5.99',
+            'typo3' => '11.1.0-13.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Add support for v11, v12 and v13 in composer.json and
ext_emconf.php to facilitate testing with v11 and v12.

----

Note:

I had the same problem in v11 as described in https://github.com/derhansen/xclass_di/issues/1. 
I wanted to the test with this extension in v11 to check if it also works with v11. 

The extension worked with v11. (I still don't know what the problem is with my version).

I am adding this as PR to make it easier for others to test / debug with versions v11 and v12.

The hint in the documentation is listed for versions v11 - main (bottom of page):

https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ApiOverview/Xclasses/Index.html#xclasses-coding